### PR TITLE
Add JavaScript for anchor link navigation.

### DIFF
--- a/src/misc/template.html
+++ b/src/misc/template.html
@@ -26,5 +26,49 @@
 <article class="markdown-body">
 [content]
 </article>
+<script>
+const findElementByFragmentName = (document, name) => {
+  if (name === '') return null
+  return document.getElementById(name) ?? document.getElementsByName(name)[0] ?? null
+}
+
+const decodeFragmentValue = (hash) => {
+  try {
+    return decodeURIComponent(hash.slice(1))
+  } catch {
+    return ''
+  }
+}
+
+function hashchange () {
+  const hash = decodeFragmentValue(location.hash)
+
+  const normalizedHash = hash.startsWith('user-content-') ? hash : `user-content-${hash}`
+
+  const target =
+    findElementByFragmentName(document, normalizedHash) ??
+    findElementByFragmentName(document, normalizedHash.toLowerCase())
+
+  if (target) {
+    target.scrollIntoView()
+  }
+}
+
+window.addEventListener('hashchange', hashchange)
+
+hashchange();
+
+[...document.querySelectorAll('a[href]')].forEach(a => a.addEventListener('click', (event) => {
+  const { currentTarget } = event
+  if (!(currentTarget instanceof HTMLAnchorElement)) return
+
+  if (currentTarget.href === location.href && location.hash.length > 1) {
+    setTimeout(function () {
+      if (!event.defaultPrevented) hashchange()
+    })
+  }
+})
+)
+</script>
 </body>
 </html>


### PR DESCRIPTION
Add the missing JavaScript that GitHub uses to make anchor links navigate as expected.